### PR TITLE
fix: Upgrade release please to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Release
-              uses: googleapis/release-please-action@v4
+              uses: googleapis/release-please-action@v5
               with:
                   token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
                   manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Updates to release please v5, so that we can remove the unset of NPM_AUTH_TOKEN via the upgrade to Node.js 24 which address the auth token patch.