### PR TITLE
fix: Remove NODE_AUTH_TOKEN unset for publishing with provenance

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,4 +30,4 @@ jobs:
               run: npm run build
 
             - name: Publish to NPM with provenance
-              run: NODE_AUTH_TOKEN="" npm publish --access public --provenance
+              run: npm publish --access public --provenance


### PR DESCRIPTION
No longer necessary after the upgrade of the release please action to Node.js 24.