### PR TITLE
fix: Only use exported functions

### DIFF
--- a/components/FontLoader.astro
+++ b/components/FontLoader.astro
@@ -1,7 +1,6 @@
 ---
-import { getFontsPackageInfo } from '../src/fonts/index.ts';
-import { getFontsCss } from '../src/css/get.ts';
-import type { FontConfig, PreloadEntry } from '../src/types.ts';
+import { getFontsPackageInfo, getFontsCss } from 'astro-font-loader';
+import type { FontConfig, PreloadEntry } from 'astro-font-loader';
 
 interface Props {
 	/** Font configurations to load. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export { fontsIntegration } from "./integration.ts";
+export { getFontsCss } from "./css/index.ts";
+export { getFontsPackageInfo } from "./fonts/index.ts";
 
 export type { FontLoaderConfig, FontConfig, FontSource, PackageProvider, FontVariant, PreloadEntry } from "./types.ts";


### PR DESCRIPTION
The component cannot resolve the local files at build time, so export the necessary functions and utilize them from the surfaced package interface.

